### PR TITLE
Fix up all but 1 Process test; introduce test_utils/strategies

### DIFF
--- a/grapl_analyzerlib/nodes/comparators.py
+++ b/grapl_analyzerlib/nodes/comparators.py
@@ -6,8 +6,8 @@ from grapl_analyzerlib.nodes.types import PropertyT
 T = TypeVar("T", bound=Union[str, int])
 
 PropertyFilter = List[List["Cmp[T]"]]
-StrCmp = Union[str, List[str], List[Union[str, "Not[str]"]]]
-IntCmp = Union[int, List[int], List[Union[int, "Not[int]"]]]
+StrCmp = Union[str, "Not[str]", List[str], List[Union[str, "Not[str]"]]]
+IntCmp = Union[int, "Not[int]", List[int], List[Union[int, "Not[int]"]]]
 
 
 def escape_dgraph_regexp(input: str) -> str:
@@ -25,7 +25,6 @@ def escape_dgraph_regexp(input: str) -> str:
 
 
 def escape_dgraph_str(input: str, query=False) -> str:
-
     output = ""
     for char in input:
         if char == "$":

--- a/grapl_analyzerlib/nodes/viewable.py
+++ b/grapl_analyzerlib/nodes/viewable.py
@@ -330,7 +330,8 @@ class Viewable(abc.ABC):
         for prop, into in cls._get_property_types().items():
             val = d.get(prop)
 
-            if val or val == 0:
+            # should this just be an is-not-None?
+            if val or val == 0 or val == "":
                 if into == str:
                     val = unescape_dgraph_str(str(val))
                 elif into == int:

--- a/grapl_analyzerlib/nodes/viewable.py
+++ b/grapl_analyzerlib/nodes/viewable.py
@@ -330,8 +330,7 @@ class Viewable(abc.ABC):
         for prop, into in cls._get_property_types().items():
             val = d.get(prop)
 
-            # should this just be an is-not-None?
-            if val or val == 0 or val == "":
+            if val is not None:
                 if into == str:
                     val = unescape_dgraph_str(str(val))
                 elif into == int:

--- a/grapl_analyzerlib/plugin_retriever.py
+++ b/grapl_analyzerlib/plugin_retriever.py
@@ -6,7 +6,7 @@ import boto3
 
 
 def load_plugins(bucket_prefix: str, s3=None):
-    s3 = s3 or boto3.resource('s3')
+    s3 = s3 or boto3.resource("s3")
 
     PluginRetriever(
         plugin_bucket=bucket_prefix + "-model-plugins-bucket",
@@ -16,58 +16,51 @@ def load_plugins(bucket_prefix: str, s3=None):
 
 
 def load_plugins_local():
-    bucket_prefix = 'local-grapl'
+    bucket_prefix = "local-grapl"
     s3 = boto3.resource(
-        's3',
+        "s3",
         endpoint_url="http://s3:9000",
-        aws_access_key_id='minioadmin',
-        aws_secret_access_key='minioadmin',
+        aws_access_key_id="minioadmin",
+        aws_secret_access_key="minioadmin",
     )
 
     load_plugins(bucket_prefix, s3)
 
 
 class PluginRetriever(object):
-    def __init__(
-            self,
-            plugin_bucket: str,
-            plugin_directory: str,
-            s3_client,
-    ) -> None:
+    def __init__(self, plugin_bucket: str, plugin_directory: str, s3_client,) -> None:
         self.plugin_bucket = plugin_bucket
         self.s3_client = s3_client
         self.plugin_directory = plugin_directory
 
     def retrieve(self, overwrite: bool = False) -> None:
         # list plugin files
-        plugin_objects = self.s3_client.list_objects(
-            Bucket=self.plugin_bucket,
-        ).get('Contents', [])
+        plugin_objects = self.s3_client.list_objects(Bucket=self.plugin_bucket,).get(
+            "Contents", []
+        )
 
         # Download each one to the /plugins/ directory
         for plugin_object in plugin_objects:
-            object_key = plugin_object['Key']
-            local_path = (
-                os.path.join(
-                    os.path.abspath("."),
-                    f"model_plugins/{base64.decodebytes(object_key.encode('utf8')).decode('utf8')}"
-                ).replace("-", "_")
-            )
+            object_key = plugin_object["Key"]
+            local_path = os.path.join(
+                os.path.abspath("."),
+                f"model_plugins/{base64.decodebytes(object_key.encode('utf8')).decode('utf8')}",
+            ).replace("-", "_")
 
             if not overwrite:
                 if os.path.isfile(local_path):
                     continue
 
             response = (
-                self.s3_client.get_object(
-                    Bucket=self.plugin_bucket,
-                    Key=object_key
-                )
-                ['Body'].read().decode('utf8')
+                self.s3_client.get_object(Bucket=self.plugin_bucket, Key=object_key)[
+                    "Body"
+                ]
+                .read()
+                .decode("utf8")
             )
 
             directory = Path(os.path.dirname(local_path))
             directory.mkdir(parents=True, exist_ok=True)
 
-            with open(local_path, 'w') as f:
+            with open(local_path, "w") as f:
                 f.write(response)

--- a/test_utils/strategies/asset_view_strategy.py
+++ b/test_utils/strategies/asset_view_strategy.py
@@ -1,0 +1,26 @@
+import unittest
+from typing import NewType, Dict, cast
+
+import hypothesis.strategies as st
+from pydgraph import DgraphClient
+
+from grapl_analyzerlib.nodes.asset_node import AssetView
+from grapl_analyzerlib.nodes.types import Property
+from test_utils.dgraph_utils import node_key_for_test, upsert
+
+AssetProps = NewType("AssetProps", Dict[str, Property])
+
+
+def asset_props() -> st.SearchStrategy[AssetProps]:
+    return st.builds(
+        AssetProps, st.builds(dict, node_key=st.uuids(), hostname=st.text(),)
+    )
+
+
+def get_or_create_asset(
+    test: unittest.TestCase, local_client: DgraphClient, node_props: AssetProps
+) -> AssetView:
+    node_key = node_key_for_test(test, str(node_props["node_key"]))
+    return cast(
+        AssetView, upsert(local_client, "Asset", AssetView, node_key, node_props)
+    )

--- a/test_utils/strategies/misc.py
+++ b/test_utils/strategies/misc.py
@@ -1,0 +1,18 @@
+from typing import Callable, Text, TypeVar
+
+from hypothesis import assume
+from hypothesis import strategies as st
+
+
+T = TypeVar("T", bound=str)
+
+
+@st.composite
+def text_dgraph_compat(draw: Callable[[st.SearchStrategy[str]], str],) -> str:
+    base_text = draw(st.text(min_size=3))
+    # Don't fuck with newlines due to a dgraph bug
+    # https://github.com/dgraph-io/dgraph/issues/4694
+    assume(len(base_text) > 3)
+    assume("\n" not in base_text)
+    assume("\\" not in base_text)
+    return base_text

--- a/test_utils/strategies/process_view_strategy.py
+++ b/test_utils/strategies/process_view_strategy.py
@@ -1,0 +1,36 @@
+import unittest
+from typing import NewType, Dict, cast
+
+import hypothesis.strategies as st
+from pydgraph import DgraphClient
+
+from grapl_analyzerlib.nodes.process_node import ProcessView
+from grapl_analyzerlib.nodes.types import Property
+from test_utils.dgraph_utils import node_key_for_test, upsert
+
+ProcessProps = NewType("ProcessProps", Dict[str, Property])
+
+
+def process_props() -> st.SearchStrategy[ProcessProps]:
+    return st.builds(
+        ProcessProps,
+        st.builds(
+            dict,
+            node_key=st.uuids(),
+            process_id=st.integers(min_value=1, max_value=2 ** 32),
+            created_timestamp=st.integers(min_value=0, max_value=2 ** 48),
+            terminate_time=st.integers(min_value=0, max_value=2 ** 48),
+            image_name=st.text(),
+            process_name=st.text(),
+            arguments=st.text(),
+        ),
+    )
+
+
+def get_or_create_process(
+    test: unittest.TestCase, local_client: DgraphClient, node_props: ProcessProps
+) -> ProcessView:
+    node_key = node_key_for_test(test, str(node_props["node_key"]))
+    return cast(
+        ProcessView, upsert(local_client, "Process", ProcessView, node_key, node_props)
+    )


### PR DESCRIPTION
Sorry, this diff is pretty chunky.

A) I fixed most of the process tests, mostly they just depended on asset IDs. There is one test that still fails due to regex escaping.
B) I've introduced a new pattern to generate props-for-upsertion: test_utils/strategies

don't forget to expand the diff on test_process_node.py it's collapsed by default